### PR TITLE
Missing IsValid() check, new convars and better addon support

### DIFF
--- a/gamemodes/ultimateph/gamemode/cl_init.lua
+++ b/gamemodes/ultimateph/gamemode/cl_init.lua
@@ -76,8 +76,15 @@ function GM:CalcView(ply, pos, angles, fov)
 			local mins = ply:GetNWVector("disguiseMins")
 			local view = {}
 			local reach = (maxs.z - mins.z)
-			if self:GetRoundSettings() && self:GetRoundSettings().PropsCamDistance then
-				reach = reach * self:GetRoundSettings().PropsCamDistance
+			
+			if reach <= GetConVar("ph_props_camdistance_min"):GetInt() then 
+				reach = GetConVar("ph_props_camdistance_min"):GetInt() 
+			end
+			
+			reach = reach * GetConVar("ph_props_camdistance_mult"):GetInt()
+			
+			if reach >= GetConVar("ph_props_camdistance_max"):GetInt() then
+				reach = GetConVar("ph_props_camdistance_max"):GetInt()
 			end
 
 			local trace = {}

--- a/gamemodes/ultimateph/gamemode/sh_init.lua
+++ b/gamemodes/ultimateph/gamemode/sh_init.lua
@@ -18,7 +18,9 @@ GM.HunterAimRay = CreateConVar("ph_hunter_aim_laser", 0, bit.bor(FCVAR_ARCHIVE, 
 GM.PropsWinStayProps = CreateConVar("ph_props_onwinstayprops", 0, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "If the props win, they stay on the props team")
 GM.PropsSmallSize = CreateConVar("ph_props_small_size", 200, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Size that speed penalty for small size starts to apply (0 to disable)")
 GM.PropsJumpPower = CreateConVar("ph_props_jumppower", 1.2, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Jump power bonus for when props are disguised")
-GM.PropsCamDistance = CreateConVar("ph_props_camdistance", 1, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "The camera distance multiplier for props when disguised")
+GM.PropsCamDistanceMult = CreateConVar("ph_props_camdistance_mult", 1, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "The camera distance multiplier for props when disguised")
+GM.PropsCamDistanceMin = CreateConVar("ph_props_camdistance_min", 60, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "The minimum camera distance for props when disguised")
+GM.PropsCamDistanceMax = CreateConVar("ph_props_camdistance_max", 160, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "The maximum camera distance for props when disguised")
 GM.PropsSilentFootsteps = CreateConVar("ph_props_silent_footsteps", 0, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Does props emit footsteps sounds while moving")
 GM.PropTpose = CreateConVar("ph_props_tpose", 0, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Should props be fully animated or Tpose")
 GM.PropUndisguisedThirdperson = CreateConVar("ph_props_undisguised_thirdperson", 0, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Should props start in thirdperson")
@@ -33,3 +35,10 @@ GM.AutoTauntMax = CreateConVar("ph_auto_taunt_delay_max", 120, bit.bor(FCVAR_ARC
 GM.AutoTauntPropsOnly = CreateConVar("ph_auto_taunt_props_only", 1, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Enable auto taunt for props only")
 
 GM.Secrets =  CreateConVar("ph_secrets", 0, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Enable secrets")
+
+GM.WalkSpeed = CreateConVar("ph_walk_speed", 200, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Walk Speed")
+GM.RunSpeed = CreateConVar("ph_run_speed", 150, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Run Speed")
+GM.JumpPower = CreateConVar("ph_jump_power", 200, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Jump Power")
+GM.FallDMGMult = CreateConVar("ph_falldmg_mult", 50, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Adjust fall damage")
+GM.FallDMGNonLethal = CreateConVar("ph_falldmg_nonlethal", 0, bit.bor(FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE), "Should fall damage kill")
+

--- a/gamemodes/ultimateph/gamemode/sv_mapvote.lua
+++ b/gamemodes/ultimateph/gamemode/sv_mapvote.lua
@@ -131,6 +131,13 @@ function GM:StartMapVote()
 		return
 	end
 
+	-- allow developers to override builtin mapvote
+	if hook.GetTable().PHStartMapVote then
+		self:SetGameState(ROUND_MAPVOTE)
+			hook.Run("PHStartMapVote")
+		return
+	end
+
 	self.MapVoteStart = CurTime()
 	self.MapVoteTime = 30
 	self.MapVoting = true
@@ -243,3 +250,4 @@ concommand.Add("ph_votemap", function(ply, com, args)
 		GAMEMODE:NetworkMapVotes()
 	end
 end)
+

--- a/gamemodes/ultimateph/gamemode/sv_player.lua
+++ b/gamemodes/ultimateph/gamemode/sv_player.lua
@@ -5,6 +5,7 @@ function GM:PlayerInitialSpawn(ply)
 	ply:SetTeam(team.BestAutoJoinTeam())
 
 	if self:GetGameState() != ROUND_WAIT then
+		ply:CSpectate()
 		timer.Simple(0, function()
 			if IsValid(ply) then
 				ply:KillSilent()
@@ -93,9 +94,9 @@ end
 function PlayerMeta:CalculateSpeed()
 	-- set the defaults
 	local settings = {
-		walkSpeed = 250,
-		runSpeed = 50,
-		jumpPower = 200,
+		walkSpeed = GAMEMODE.WalkSpeed:GetInt(),
+		runSpeed = GAMEMODE.RunSpeed:GetInt(),
+		jumpPower = GAMEMODE.JumpPower:GetInt(),
 		canRun = true,
 		canMove = true,
 		canJump = true
@@ -142,9 +143,11 @@ function GM:PlayerLoadout(ply)
 		ply:Give("weapon_crowbar")
 		ply:Give("weapon_smg1")
 		ply:Give("weapon_shotgun")
+		ply:Give("weapon_357")
 
 		ply:GiveAmmo(45 * 10, "SMG1")
 		ply:GiveAmmo(6 * 10, "buckshot")
+		ply:GiveAmmo(6 * 10, "357")
 		local amo = self.HunterGrenadeAmount:GetInt()
 		if amo > 0 then
 			ply:GiveAmmo(amo, "SMG1_Grenade")
@@ -504,6 +507,7 @@ end
 
 function GM:PlayerDeathThink(ply)
 	if self:CanRespawn(ply) then
+		ply:UnCSpectate()
 		ply:Spawn()
 	else
 		self:ChooseSpectatee(ply)

--- a/gamemodes/ultimateph/gamemode/sv_realism.lua
+++ b/gamemodes/ultimateph/gamemode/sv_realism.lua
@@ -21,7 +21,8 @@ end
 function GM:GetFallDamage(ply, vel)
 	if vel > 530 then
 		local minvel = vel - 530
-		local dmg = math.ceil(minvel / 278 * 50)
+		local dmg = math.ceil(minvel / 278 * GAMEMODE.FallDMGMult:GetInt())
+		if GAMEMODE.FallDMGNonLethal:GetBool() && ply:Health() <= dmg then dmg = ply:Health() - 1 end
 		return dmg
 	end
 end

--- a/gamemodes/ultimateph/gamemode/sv_rounds.lua
+++ b/gamemodes/ultimateph/gamemode/sv_rounds.lua
@@ -122,6 +122,7 @@ function GM:SetupRound()
 		if !ply:IsSpectator() then -- ignore spectators
 			ply:SetNWBool("RoundInGame", true)
 			ply:KillSilent()
+			ply:UnCSpectate()
 			ply:Spawn()
 
 			local col = team.GetColor(ply:Team())
@@ -189,7 +190,7 @@ function GM:StartRound()
 	else
 		self.RoundSettings.RoundTime = math.Round((c * 0.5 / hunters + 60 * 4)  * math.sqrt(props / hunters))
 	end
-	self.RoundSettings.PropsCamDistance = self.PropsCamDistance:GetFloat()
+	self.RoundSettings.PropsCamDistanceMult = self.PropsCamDistanceMult:GetFloat()
 	print("Round time is " .. (self.RoundSettings.RoundTime / 60) .. " (" .. c .. " props)")
 	self:NetworkGameSettings()
 	self:SetGameState(ROUND_SEEK)
@@ -205,6 +206,9 @@ function GM:EndRound(winningTeam)
 
 	self.LastRoundResult = winningTeam
 
+	hook.Run("PH".. winningTeam, ply)
+	hook.Run("PHEndRound", ply)
+
 	local awards = {}
 	for awardKey, award in pairs(PlayerAwards) do -- PlayerAwards comes from sv_awards.lua
 		local result = award.getWinner()
@@ -212,7 +216,7 @@ function GM:EndRound(winningTeam)
 		-- nil values cannot exist in awards otherwise the net.WriteTable below will break
 		if !result then
 			continue
-		elseif type(result) == "Player" then
+		elseif type(result) == "Player" && IsValid(result) then
 			awards[awardKey] = {
 				name = award.name,
 				desc = award.desc,

--- a/gamemodes/ultimateph/gamemode/sv_rounds.lua
+++ b/gamemodes/ultimateph/gamemode/sv_rounds.lua
@@ -223,6 +223,7 @@ function GM:EndRound(winningTeam)
 				winnerName = result:Nick(),
 				winnerTeam = result:Team()
 			}
+			hook.Run("PHAward", result, award)
 		else
 			ErrorNoHalt("ULTIMATEPH WARNING: EndRound Player Award gave non Player object: " .. type(result))
 		end
@@ -323,3 +324,4 @@ local function ForceEndRound(ply, command, args)
 	end
 end
 concommand.Add("ph_endround", ForceEndRound)
+

--- a/gamemodes/ultimateph/ultimateph.txt
+++ b/gamemodes/ultimateph/ultimateph.txt
@@ -145,5 +145,46 @@
 			"type"		"CheckBox"
 			"default"	"0"
 		}
+		18
+		{
+			"name"		"ph_walk_speed"
+			"text"		"Walk Speed"
+			"help"		"Default Walk Speed for hunters and props."
+			"type"		"Numeric"
+			"default"	"200"
+		}
+		19
+		{
+			"name"		"ph_run_speed"
+			"text"		"Run Speed"
+			"help"		"Default Run Speed for hunters and props."
+			"type"		"Numeric"
+			"default"	"150"
+		}
+		20
+		{
+			"name"		"ph_jump_power"
+			"text"		"Jump Power"
+			"help"		"Default Jump Power for hunters and props."
+			"type"		"Numeric"
+			"default"	"200"
+		}
+		21
+		{
+			"name"		"ph_falldmg_mult"
+			"text"		"Fall Damage multiplier"
+			"help"		"Default Fall Damage multiplier for hunters and props."
+			"type"		"Numeric"
+			"default"	"50"
+		}
+		22
+		{
+			"name"		"ph_falldmg_nonlethal"
+			"text"		"Non-Lethal Fall Damage"
+			"help"		"If set, fall damage will not take players below one health."
+			"type"		"CheckBox"
+			"default"	"0"
+		}
 	}
 }
+

--- a/gamemodes/ultimateph/ultimateph.txt
+++ b/gamemodes/ultimateph/ultimateph.txt
@@ -185,6 +185,31 @@
 			"type"		"CheckBox"
 			"default"	"0"
 		}
+		23
+		{
+			"name"		"ph_props_camdistance_mult"
+			"text"		"Prop Camera Distance Multiplier"
+			"help"		"The camera distance multiplier for props when disguised"
+			"type"		"Numeric"
+			"default"	"1"
+		}
+		24
+		{
+			"name"		"ph_props_camdistance_min"
+			"text"		"Props Minimum Camera Distance"
+			"help"		"The minimum camera distance for props when disguised"
+			"type"		"Numeric"
+			"default"	"60"
+		}
+		25
+		{
+			"name"		"ph_props_camdistance_max"
+			"text"		"Props Maximum Camera Distance"
+			"help"		"The maximum camera distance for props when disguised"
+			"type"		"Numeric"
+			"default"	"160"
+		}
 	}
 }
+
 

--- a/lua/ulx/modules/sh/ultimateph.lua
+++ b/lua/ulx/modules/sh/ultimateph.lua
@@ -100,9 +100,19 @@ commandToUlx("ph_props_jumppower", function(c)
     c:help("Set the jump power bonus for props.")
 end)
 
-commandToUlx("ph_props_camdistance", function(c)
+commandToUlx("ph_props_camdistance_mult", function(c)
     c:addParam{ type = ULib.cmds.NumArg, default = 1, min = 1, max = 10, hint = "distance", ULib.cmds.round, ULib.cmds.optional }
     c:help("Set the camera distance multiplier for disguised props.")
+end)
+
+commandToUlx("ph_props_camdistance_min", function(c)
+    c:addParam{ type = ULib.cmds.NumArg, default = 60, min = 1, max = 1000, hint = "mindistance", ULib.cmds.round, ULib.cmds.optional }
+    c:help("Set the camera minimum camera distance for props.")
+end)
+
+commandToUlx("ph_props_camdistance_max", function(c)
+    c:addParam{ type = ULib.cmds.NumArg, default = 160, min = 1, max = 1000, hint = "maxdistance", ULib.cmds.round, ULib.cmds.optional }
+    c:help("Set the camera maximum camera distance for props.")
 end)
 
 commandToUlx("ph_props_silent_footsteps", function(c)
@@ -145,6 +155,31 @@ commandToUlx("ph_auto_taunt", function(c)
     c:help("Enable/disable auto taunt.")
 end)
 
+commandToUlx("ph_walk_speed", function(c)
+    c:addParam{ type = ULib.cmds.NumArg, default = 200, min = 10, max = 1000, hint = "walk", ULib.cmds.optional }
+    c:help("Set the default walk speed for hunters and props.")
+end)
+
+commandToUlx("ph_run_speed", function(c)
+    c:addParam{ type = ULib.cmds.NumArg, default = 150, min = 10, max = 1000, hint = "run", ULib.cmds.optional }
+    c:help("Set the default run speed for hunters and props.")
+end)
+
+commandToUlx("ph_jump_power", function(c)
+    c:addParam{ type = ULib.cmds.NumArg, default = 200, min = 10, max = 1000, hint = "jump", ULib.cmds.optional }
+    c:help("Set the default jump power for hunters and props.")
+end)
+
+commandToUlx("ph_falldmg_mult", function(c)
+    c:addParam{ type = ULib.cmds.NumArg, default = 50, min = 0, max = 1000, hint = "falldmg", ULib.cmds.optional }
+    c:help("Adjust fall damage for hunters and props.")
+end)
+
+commandToUlx("ph_falldmg_nonlethal", function(c)
+    c:addParam{ type = ULib.cmds.BoolArg, hint = "enabled", ULib.cmds.optional }
+    c:help("Set fall damage lethality.")
+end)
+
 function ulx.ultimatephAutoTauntDelay(calling_ply, minimum, maximum)
     if minimum > maximum then
         minimum = maximum
@@ -170,3 +205,4 @@ end)
 commandToUlx("ph_endround", function(c)
     c:help("Ends the round on a tie.")
 end)
+


### PR DESCRIPTION
A missing IsValid() check has been added to the end of round rewards, to prevent the gamemode breaking should somebody leave in the narrow window between end of round and rewards being given.

ply:UnCSpectate() has been added before every instance of ply:Spawn() to help addons which hook GM:PlayerSpawn() and also have a IsSpectating() check, such as pointshop and other playermodel-setting addons

The following convars have been added:
ph_walk_speed
ph_run_speed
ph_jump_power
ph_falldmg_mult
ph_falldmg_nonlethal - if enabled, will prevent fall damage from ever taking the player below 1hp
ph_props_camdistance_mult - renamed from ph_props_camdistance in light of new camera convars
ph_props_camdistance_min - some props have a very tiny camdistance, like cans, this will make things less claustrophobic without needing to set a ridiculously high multiplier
ph_props_camdistance_max - I added this for the sake of completeness but have not found a real use yet